### PR TITLE
Use LTI System block inside of Optickle FRD block

### DIFF
--- a/SimulinkNb/buildOptickleSys.m
+++ b/SimulinkNb/buildOptickleSys.m
@@ -97,7 +97,7 @@ function buildOptickleSys(varargin)
     % add internal dummy system
     dummyBlock = add_block('cstblocks/LTI System',[sys '/' optName '/' dummyName]);
     set(dummyBlock,'Position',origin.internalDummy);
-    set_param([sys '/' optName '/' dummyName],'sys',['repmat(tf(1,[1,1]),[' num2str(length(outputs)) ',' num2str(length(inputs)) '])']);
+    set_param([sys '/' optName '/' dummyName],'sys',['repmat(tf(1),[' num2str(length(outputs)) ',' num2str(length(inputs)) '])']);
     %set(dummyBlock,
     mux = add_block('built-in/Mux',[sys '/' optName '/' muxName]);
     set(mux,'Position',origin.internalMux);


### PR DESCRIPTION
This would allow the user to easily replace the internal optickle transfer functions with a valid matlab LTI system (e.g. state space model). Thus, if the user produces valid transfer functions, the model could be run in standard simulink (non flexTF) contexts.