### PR TITLE
Multiplexing for noise source blocks

### DIFF
--- a/SimulinkNb/nbGroupNoises.m
+++ b/SimulinkNb/nbGroupNoises.m
@@ -18,8 +18,8 @@ elseif ~iscell(noises)
     error('The noises are not a cell array');
 elseif ~isobject(sys)
     error('The sys object is not an object');
-elseif size(sys, 2) ~= numel(noises) + 1
-    error('The noises and the sys object have mismatched dimensions')
+%elseif size(sys, 2) ~= numel(noises) + 1
+%    error('The noises and the sys object have mismatched dimensions')
 end
 
 %% Get the DOF and unit settings from the NbNoiseCal block
@@ -68,14 +68,26 @@ end
 noisesByGroup = containers.Map();
 for n = 1:numel(noises)
     noise = noises{n};
-    blkVars = get_param(noise.name, 'MaskWSVariables');
+    nameParts = regexp(noise.name, '(.*)\{(\d+)\}', 'tokens');
+    blk = nameParts{1}{1};
+    multiplex = str2double(nameParts{1}{2});
+    blkVars = get_param(blk, 'MaskWSVariables');
     blkVars = containers.Map({blkVars.Name}, {blkVars.Value});
-    if blkVars('groupNest') >= level
-        groupName = blkVars(groupVar{level});
+    if iscell(blkVars('group'))
+        groupInfo = blkVars('group');
+        groupInfo = groupInfo{multiplex};
+    else
+        groupInfo = struct('groupNest', blkVars('groupNest'), ...
+            'group', blkVars('group'), 'subgroup', blkVars('subgroup'), ...
+            'subsubgroup', blkVars('subsubgroup'), ...
+            'subsubsubgroup', blkVars('subsubsubgroup'));
+    end
+    if groupInfo.groupNest >= level
+        groupName = groupInfo.(groupVar{level});
         if ~ischar(groupName)
             error(['Invalid NbNoiseSource block ' noise.name char(10) ...
                 'The ' groupVar{level} ' parameter (' ...
-                get_param(noise.name, groupVar{level}) ') must be a string']);
+                get_param(blk, groupVar{level}) ') must be a string']);
         end
     else
         groupName = noise.name;


### PR DESCRIPTION
Noise source blocks can now stand in for multiple sources.  This
allows simplifying complex subsystems (e.g. suspensions) to just
a few blocks so the model runs fast.  A multiplexed noise source
is configured as follows:
 ASD - cell array of ASDs
 DAQ channel - cell array of structs; fields 'chan' (channel name)
 and 'tf' (LTI object used to recalibrate the data)
 Group nesting - should be set to 1
 Group - cell array of structs; fields 'groupNest', 'group',
 'subgroup', 'subsubgroup' and 'subsubsubgroup'
Yet-to-be-solved issues:
 How to handle coherence between multiple outputs
 Auto-generating these sources
 Robustness, error handling, documentation updates