### PR TITLE
Adding Virgo data reading

### DIFF
--- a/SimulinkNb/getVirgoData.m
+++ b/SimulinkNb/getVirgoData.m
@@ -1,0 +1,36 @@
+function out = getVirgoData(channels,dtype,start_time,duration)
+%GETVIRGODATA  Read Virgo data from ffl file index
+%
+% data = getVirgoData(channels,dtype,start_time,duration)
+%
+% Input:
+% channels - string or cell array of strings with channel names
+% dtype - data type (raw, trend, ...), data will be read from dtype.ffl file
+% start_time - GPS start time of data to read
+% duration - duration in seconds of data stretch to read
+%
+% Output:
+% data - object array containing data for each requested channel
+%   data(ii).name - channel name
+%   data(ii).data - data time series
+%   data(ii).rate - sampling rate of data
+%   data(ii).start - GPS start time of time series
+%   data(ii).duration - duration in seconds of time series
+
+if isstr(channels)
+  channels = {channels};
+end
+
+for ii=1:length(channels)
+  
+  [data time] = frgetvectN(['/virgoData/ffl/' dtype '.ffl'], ...
+                      channels{ii}, start_time, duration);
+
+  out(ii).name = channels{ii}
+  out(ii).data = data;
+  out(ii).rate = 1/(time(2)-time(1));
+  out(ii).start = time(1);
+  out(ii).duration = duration;
+
+end
+

--- a/SimulinkNb/liveParts.m
+++ b/SimulinkNb/liveParts.m
@@ -31,7 +31,17 @@ end
 
 chanList = sort(unique(chanList));
 
-data = cacheFunction(@getNdsData, chanList, start, duration);
+%% Read data using NDS (LIGO) or from ffl file (Virgo)
+% find which channels are for Virgo
+virgoChannels = ~cellfun(@isempty, regexp(chanList, '^V1:.*'));
+if all(virgoChannels)
+  % if all channels are from Virgo use getVirgoData
+  % FIXME: hard-coded using raw_full frames
+  data = cacheFunction(@getVirgoData, chanList, 'raw_full', start, duration);
+else
+  % use NDS for all channels if any LIGO channels is requested
+  data = cacheFunction(@getNdsData, chanList, start, duration);
+end
 
 dataByChan = containers.Map();
 for n = 1:numel(data)

--- a/SimulinkNb/nbAcquireData.m
+++ b/SimulinkNb/nbAcquireData.m
@@ -61,8 +61,8 @@ chanList = sort(unique(chanList));
 virgoChannels = ~cellfun(@isempty, regexp(chanList, '^V1:.*'));
 if all(virgoChannels)
   % if all channels are from Virgo use getVirgoData
-  % FIXME: hard-coded using rds frames
-  data = cacheFunction(@getVirgoData, chanList, 'rds', start, duration);
+  % FIXME: hard-coded using raw_full frames
+  data = cacheFunction(@getVirgoData, chanList, 'raw_full', start, duration);
 else
   % use NDS for all channels if any LIGO channels is requested
   data = cacheFunction(@getNdsData, chanList, start, duration);
@@ -98,7 +98,7 @@ function [ asd ] = defaultAsd(data, Fs, freq)
 
 % Pick some reasonable resolution for the spectrum, in case the freq vector
 % has nonuniform spacing
-df = geomean(diff(freq));
+df = exp(mean(log(diff(freq))));
 df = min(df, min(freq(freq>0)));
 NFFT = 2^ceil(log2(Fs/df));
 if NFFT > numel(data)

--- a/SimulinkNb/nbAcquireData.m
+++ b/SimulinkNb/nbAcquireData.m
@@ -56,7 +56,17 @@ end
 
 chanList = sort(unique(chanList));
 
-data = cacheFunction(@getNdsData, chanList, start, duration);
+%% Read data using NDS (LIGO) or from ffl file (Virgo)
+% find which channels are for Virgo
+virgoChannels = ~cellfun(@isempty, regexp(chanList, '^V1:.*'));
+if all(virgoChannels)
+  % if all channels are from Virgo use getVirgoData
+  % FIXME: hard-coded using rds frames
+  data = cacheFunction(@getVirgoData, chanList, 'rds', start, duration);
+else
+  % use NDS for all channels if any LIGO channels is requested
+  data = cacheFunction(@getNdsData, chanList, start, duration);
+end
 
 %% Compute ASDs 
 


### PR DESCRIPTION
if all channels are from Virgo will read directly data from frame instead of using NDS (non existing at Virgo site). Should not affect LIGO usage, but I haven't checked that is indeed the case. It's a bit of a hack, but I hope it is acceptable.